### PR TITLE
feat: 캘린더 컴포넌트 구현

### DIFF
--- a/src/components/common/calender/Calender.stories.tsx
+++ b/src/components/common/calender/Calender.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import Calender from './Calender.tsx'
+
+const meta: Meta<typeof Calender> = {
+  component: Calender,
+  title: 'Components/Calender',
+  tags: ['autodocs'],
+  argTypes: {
+    onClick: {
+      description: '일자를 클릭했을때 실행할 함수를 넣어주세요!',
+      control: { type: 'function' }
+    }
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof Calender>
+export const Default: Story = {
+  ...meta
+}

--- a/src/components/common/calender/Calender.tsx
+++ b/src/components/common/calender/Calender.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { defaultDate, getDays } from '../../../libs/utils/date.ts'
-import { CalenderType, MonthType } from '../../../types/date.ts'
+import { CalenderType, DaysInfo, MonthType } from '../../../types/date.ts'
 import CalenderProps from './CalenderType.ts'
 import { DECEMBER, JANUARY, WEEK, WeekStyle } from './constants.ts'
 
@@ -11,8 +11,26 @@ const Calender = ({ onClick }: CalenderProps) => {
     nowMonth: defaultMonth,
     nowDays: defaultDays
   })
-
   const { nowYear, nowMonth, nowDays } = calenderState
+
+  const handleDayClick = useCallback(
+    (dayInfo: DaysInfo) => {
+      console.log(dayInfo.month, nowMonth)
+
+      if (dayInfo.month !== nowMonth) {
+        const { year, month } = dayInfo
+        const days = getDays(year, month)
+        setCalenderState({
+          nowYear: year,
+          nowMonth: month,
+          nowDays: days
+        })
+      }
+
+      onClick(dayInfo)
+    },
+    [calenderState]
+  )
 
   const nextMonth = () => {
     let nextMonth = nowMonth + 1
@@ -105,7 +123,7 @@ const Calender = ({ onClick }: CalenderProps) => {
                 key={index}
                 className={daysInfo.style}
                 data-id={`${daysInfo.year}-${daysInfo.month}`}
-                onClick={() => onClick(daysInfo)}
+                onClick={() => handleDayClick(daysInfo)}
               >
                 {daysInfo.day}
               </div>

--- a/src/components/common/calender/Calender.tsx
+++ b/src/components/common/calender/Calender.tsx
@@ -1,29 +1,42 @@
 import { useCallback, useEffect, useState } from 'react'
 import { defaultDate, getDays } from '../../../libs/utils/date.ts'
-import { CalenderType, DaysInfo, MonthType } from '../../../types/date.ts'
+import {
+  CalenderType,
+  DaysInfo,
+  DayType,
+  MonthType
+} from '../../../types/date.ts'
 import CalenderProps from './CalenderType.ts'
 import { DECEMBER, JANUARY, WEEK, WeekStyle } from './constants.ts'
 
 const Calender = ({ onClick }: CalenderProps) => {
-  const [defaultYear, defaultMonth, defaultDays] = defaultDate()
+  const [defaultYear, defaultMonth, defaultDays, days] = defaultDate()
   const [calenderState, setCalenderState] = useState<CalenderType>({
     nowYear: defaultYear,
     nowMonth: defaultMonth,
-    nowDays: defaultDays
+    nowDays: defaultDays,
+    toDay: days
   })
-  const { nowYear, nowMonth, nowDays } = calenderState
+  const { nowYear, nowMonth, nowDays, toDay } = calenderState
 
   const handleDayClick = useCallback(
     (dayInfo: DaysInfo) => {
       console.log(dayInfo.month, nowMonth)
+      console.log(dayInfo)
 
-      if (dayInfo.month !== nowMonth) {
-        const { year, month } = dayInfo
+      if (dayInfo.month === nowMonth) {
+        setCalenderState({
+          ...calenderState,
+          toDay: dayInfo.day
+        })
+      } else {
+        const { year, month, day } = dayInfo
         const days = getDays(year, month)
         setCalenderState({
           nowYear: year,
           nowMonth: month,
-          nowDays: days
+          nowDays: days,
+          toDay: day
         })
       }
 
@@ -46,7 +59,8 @@ const Calender = ({ onClick }: CalenderProps) => {
     setCalenderState({
       nowYear: nextYear,
       nowMonth: nextMonth as MonthType,
-      nowDays: nextDays
+      nowDays: nextDays,
+      toDay: 1 as DayType
     })
   }
 
@@ -64,7 +78,8 @@ const Calender = ({ onClick }: CalenderProps) => {
     setCalenderState({
       nowYear: previousYear,
       nowMonth: previousMonth as MonthType,
-      nowDays: previousDays
+      nowDays: previousDays,
+      toDay: 1 as DayType
     })
   }
 
@@ -121,8 +136,12 @@ const Calender = ({ onClick }: CalenderProps) => {
             {week.map((daysInfo, index) => (
               <div
                 key={index}
-                className={daysInfo.style}
-                data-id={`${daysInfo.year}-${daysInfo.month}`}
+                className={`${daysInfo.style} ${
+                  daysInfo.day === toDay && daysInfo.month === nowMonth
+                    ? 'bg-[rgba(87,164,255,0.2)] rounded-full '
+                    : ''
+                }`}
+                data-id={`${daysInfo.year}-${daysInfo.month}}`}
                 onClick={() => handleDayClick(daysInfo)}
               >
                 {daysInfo.day}

--- a/src/components/common/calender/Calender.tsx
+++ b/src/components/common/calender/Calender.tsx
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useState } from 'react'
+import { defaultDate, getDays } from '../../../libs/utils/date.ts'
+import { CalenderType, DaysInfo, MonthType } from '../../../types/date.ts'
+import { DECEMBER, JANUARY, WEEK, WeekStyle } from './constants.ts'
+
+const Calender = () => {
+  const [defaultYear, defaultMonth, defaultDays] = defaultDate()
+  const [calenderState, setCalenderState] = useState<CalenderType>({
+    nowYear: defaultYear,
+    nowMonth: defaultMonth,
+    nowDays: defaultDays
+  })
+
+  const { nowYear, nowMonth, nowDays } = calenderState
+
+  const handleDayClick = useCallback((dayInfo: DaysInfo) => {
+    console.log(dayInfo)
+  }, [])
+
+  const nextMonth = () => {
+    let nextMonth = nowMonth + 1
+    let nextYear = nowYear
+
+    if (nextMonth > DECEMBER) {
+      nextYear += 1
+      nextMonth = JANUARY
+    }
+
+    const nextDays = getDays(nextYear, nextMonth as MonthType)
+
+    setCalenderState({
+      nowYear: nextYear,
+      nowMonth: nextMonth as MonthType,
+      nowDays: nextDays
+    })
+  }
+
+  const previousMonth = () => {
+    let previousYear = nowYear
+    let previousMonth = nowMonth - 1
+
+    if (previousMonth < JANUARY) {
+      previousMonth = DECEMBER
+      previousYear -= 1
+    }
+
+    const previousDays = getDays(previousYear, previousMonth as MonthType)
+
+    setCalenderState({
+      nowYear: previousYear,
+      nowMonth: previousMonth as MonthType,
+      nowDays: previousDays
+    })
+  }
+
+  useEffect(() => {
+    console.log('여기서 api콜을 해주세요~')
+  }, [calenderState])
+
+  return (
+    <div
+      className={
+        'flex flex-col justify-center items-center w-[388px] h-[343px]'
+      }
+    >
+      <div className={'flex flex-row'}>
+        <div className={'cursor-pointer'} onClick={previousMonth}>
+          {'<'}
+        </div>
+        <div>{`${nowYear}년 ${nowMonth}월`}</div>
+        <div className={'cursor-pointer'} onClick={nextMonth}>
+          {'>'}
+        </div>
+      </div>
+
+      <div
+        className={
+          'flex flex-row w-full justify-center items-center mr-[8px] ml-[11px] mt-[17px] mb-[12px]'
+        }
+      >
+        {WEEK.map((daysOfWeek, index) => (
+          <div
+            key={index}
+            className={`w-full text-center font-nsk caption-13 font-bold mr-[15px]  ${
+              daysOfWeek === 'SUN' || daysOfWeek === 'SAT'
+                ? WeekStyle[daysOfWeek]
+                : ''
+            }`}
+          >
+            {daysOfWeek}
+          </div>
+        ))}
+      </div>
+      <div
+        className={
+          'flex-col flex w-full justify-center items-center mr-[8px] ml-[11px] mb-[18px]'
+        }
+      >
+        {nowDays.map((week, index) => (
+          <div
+            key={index}
+            className={
+              'flex flex-row w-full justify-center items-center mt-[17px] mb[18px]'
+            }
+          >
+            {week.map((daysInfo, index) => (
+              <div
+                key={index}
+                className={daysInfo.style}
+                data-id={`${daysInfo.year}-${daysInfo.month}`}
+                onClick={() => handleDayClick(daysInfo)}
+              >
+                {daysInfo.day}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default Calender

--- a/src/components/common/calender/Calender.tsx
+++ b/src/components/common/calender/Calender.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { defaultDate, getDays } from '../../../libs/utils/date.ts'
-import { CalenderType, DaysInfo, MonthType } from '../../../types/date.ts'
+import { CalenderType, MonthType } from '../../../types/date.ts'
+import CalenderProps from './CalenderType.ts'
 import { DECEMBER, JANUARY, WEEK, WeekStyle } from './constants.ts'
 
-const Calender = () => {
+const Calender = ({ onClick }: CalenderProps) => {
   const [defaultYear, defaultMonth, defaultDays] = defaultDate()
   const [calenderState, setCalenderState] = useState<CalenderType>({
     nowYear: defaultYear,
@@ -12,10 +13,6 @@ const Calender = () => {
   })
 
   const { nowYear, nowMonth, nowDays } = calenderState
-
-  const handleDayClick = useCallback((dayInfo: DaysInfo) => {
-    console.log(dayInfo)
-  }, [])
 
   const nextMonth = () => {
     let nextMonth = nowMonth + 1
@@ -108,7 +105,7 @@ const Calender = () => {
                 key={index}
                 className={daysInfo.style}
                 data-id={`${daysInfo.year}-${daysInfo.month}`}
-                onClick={() => handleDayClick(daysInfo)}
+                onClick={() => onClick(daysInfo)}
               >
                 {daysInfo.day}
               </div>

--- a/src/components/common/calender/Calender.tsx
+++ b/src/components/common/calender/Calender.tsx
@@ -88,11 +88,7 @@ const Calender = ({ onClick }: CalenderProps) => {
   }, [calenderState])
 
   return (
-    <div
-      className={
-        'flex flex-col justify-center items-center w-[388px] h-[343px]'
-      }
-    >
+    <div className={'flex flex-col justify-center items-center w-[388px]'}>
       <div className={'flex flex-row'}>
         <div className={'cursor-pointer'} onClick={previousMonth}>
           {'<'}

--- a/src/components/common/calender/CalenderType.ts
+++ b/src/components/common/calender/CalenderType.ts
@@ -1,0 +1,7 @@
+import { DaysInfo } from '../../../types/date.ts'
+
+interface CalenderProps {
+  onClick: (daysInfo: DaysInfo) => void
+}
+
+export default CalenderProps

--- a/src/components/common/calender/constants.ts
+++ b/src/components/common/calender/constants.ts
@@ -4,7 +4,7 @@ export const WEEK = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
 export const defaultWeek = [0, 0, 0, 0, 0, 0, 0]
 export const WeekStyle = {
   WEEKDAY:
-    'w-full text-center cursor-pointer font-nsk caption-13 font-bold mr-[15px]',
+    'w-full h-[40px] text-center justify-center items-center leading-[40px] cursor-pointer font-nsk caption-13 font-bold mr-[15px]',
   SUN: 'text-red-500',
   SAT: 'text-blue-500',
   OPACITY: 'opacity-20'

--- a/src/components/common/calender/constants.ts
+++ b/src/components/common/calender/constants.ts
@@ -1,0 +1,14 @@
+import { MonthType } from '../../../types/date.ts'
+
+export const WEEK = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
+export const defaultWeek = [0, 0, 0, 0, 0, 0, 0]
+export const WeekStyle = {
+  WEEKDAY:
+    'w-full text-center cursor-pointer font-nsk caption-13 font-bold mr-[15px]',
+  SUN: 'text-red-500',
+  SAT: 'text-blue-500',
+  OPACITY: 'opacity-20'
+}
+
+export const DECEMBER = 12 as MonthType
+export const JANUARY = 1 as MonthType

--- a/src/libs/utils/date.ts
+++ b/src/libs/utils/date.ts
@@ -1,0 +1,108 @@
+import {
+  DECEMBER,
+  JANUARY,
+  WeekStyle
+} from '../../components/common/calender/constants.ts'
+import { MonthType, DaysInfo, DayType } from '../../types/date.ts'
+
+export const defaultDate = (): [number, MonthType, DaysInfo[][]] => {
+  const nowDate = new Date()
+  const year = nowDate.getFullYear()
+  const month = (nowDate.getMonth() + 1) as MonthType
+  const days = getDays(year, month)
+
+  return [year, month, days]
+}
+
+export const getPrevDays = (
+  year: number,
+  month: MonthType
+): [number, MonthType] => {
+  return [year, month]
+}
+
+export const getDays = (year: number, month: MonthType) => {
+  //실제 Month 데이터는 0 ~ 11이기 때문에 -1 해줘야 한다.
+  const nowMonth = month - 1
+  const lastDay = getLastDayOfMonth(year, month)
+  const lastWeek = getLastWeeksOfMonth(year, month)
+
+  const weeks: DaysInfo[][] = Array.from<DaysInfo[]>({ length: lastWeek })
+    .fill([])
+    .map(() =>
+      Array.from<DaysInfo>({ length: 7 }).fill({
+        year: year,
+        month: month,
+        day: 0,
+        style: ''
+      })
+    )
+
+  const firstDay = new Date(year, nowMonth, 1).getDay()
+  //이번달
+  for (let day = 1; day <= lastDay; day++) {
+    const currentDate = new Date(year, nowMonth, day)
+    const dayOfWeek = currentDate.getDay() // 0 (일요일) ~ 6 (토요일)
+    const weekNumber = Math.floor((day - 1 + firstDay) / 7)
+    weeks[weekNumber][dayOfWeek] = {
+      ...weeks[weekNumber][dayOfWeek],
+      day: day as DayType,
+      style: `${WeekStyle.WEEKDAY} ${dayOfWeek === 0 ? WeekStyle.SUN : ''} ${
+        dayOfWeek === 6 ? WeekStyle.SAT : ''
+      }`
+    }
+  }
+
+  //이전달
+  const prevMonth =
+    month - 1 === 0 ? (DECEMBER as MonthType) : ((month - 1) as MonthType)
+  const prevYear = month - 1 === 0 ? year - 1 : year
+
+  const prevMonthLastDay = getLastDayOfMonth(prevYear, prevMonth)
+  for (let i = 0; i < firstDay; i++) {
+    weeks[0][i] = {
+      year: prevYear,
+      month: prevMonth,
+      day: (prevMonthLastDay - firstDay + i + 1) as DayType,
+      style: `${WeekStyle.WEEKDAY} ${WeekStyle.OPACITY}`
+    }
+  }
+
+  // 다음달
+  // 마지막 주에서 0의 값을 다음 달의 데이터로 채우기
+  const nextMonth = (month + 1 === 13 ? JANUARY : month + 1) as MonthType
+  const nextYear = month + 1 === 13 ? year + 1 : year
+  let nextMonthDay = 1
+  for (let dayOfWeek = 0; dayOfWeek < 7; dayOfWeek++) {
+    if (weeks[lastWeek - 1][dayOfWeek]['day'] === 0) {
+      weeks[lastWeek - 1][dayOfWeek] = {
+        year: nextYear,
+        month: nextMonth,
+        day: nextMonthDay as DayType,
+        style: `${WeekStyle.WEEKDAY} ${WeekStyle.OPACITY} ${
+          dayOfWeek === 0 ? WeekStyle.SUN : ''
+        } ${dayOfWeek === 6 ? WeekStyle.SAT : ''}`
+      }
+      nextMonthDay++
+    }
+  }
+
+  return weeks
+}
+
+function getLastDayOfMonth(year: number, month: MonthType) {
+  // month는 0부터 시작 (0: 1월, 1: 2월, ... 11: 12월)
+  return new Date(year, month, 0).getDate()
+}
+
+function getLastWeeksOfMonth(year: number, month: MonthType) {
+  const firstDate = new Date(year, month - 1, 1)
+  const lastDate = new Date(year, month, 0)
+
+  const firstDay = firstDate.getDay()
+
+  // 첫 주와 마지막 주를 포함하여 계산
+  const weeks = Math.ceil((lastDate.getDate() + firstDay) / 7)
+
+  return weeks
+}

--- a/src/libs/utils/date.ts
+++ b/src/libs/utils/date.ts
@@ -5,13 +5,14 @@ import {
 } from '../../components/common/calender/constants.ts'
 import { MonthType, DaysInfo, DayType } from '../../types/date.ts'
 
-export const defaultDate = (): [number, MonthType, DaysInfo[][]] => {
+export const defaultDate = (): [number, MonthType, DaysInfo[][], DayType] => {
   const nowDate = new Date()
   const year = nowDate.getFullYear()
   const month = (nowDate.getMonth() + 1) as MonthType
   const days = getDays(year, month)
+  const today = nowDate.getDate() as DayType
 
-  return [year, month, days]
+  return [year, month, days, today]
 }
 
 export const getPrevDays = (

--- a/src/types/date.ts
+++ b/src/types/date.ts
@@ -44,4 +44,5 @@ export interface CalenderType {
   nowYear: number
   nowMonth: MonthType
   nowDays: DaysInfo[][]
+  toDay: DayType
 }

--- a/src/types/date.ts
+++ b/src/types/date.ts
@@ -1,0 +1,47 @@
+export type MonthType = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
+export type DayType =
+  | 0
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+  | 13
+  | 14
+  | 15
+  | 16
+  | 17
+  | 18
+  | 19
+  | 20
+  | 21
+  | 22
+  | 23
+  | 24
+  | 25
+  | 26
+  | 27
+  | 28
+  | 29
+  | 30
+  | 31
+
+export type DaysInfo = {
+  year: number
+  month: MonthType
+  day: DayType
+  style: string
+}
+
+export interface CalenderType {
+  nowYear: number
+  nowMonth: MonthType
+  nowDays: DaysInfo[][]
+}


### PR DESCRIPTION
## 내용 설명
캘린더 컴포넌트를 구현하였습니다.

## 구현 내용
- 이전달, 다음달로 이동
- 일 클릭시 다음 객체를 반환합니다.
ex){
   day:  number 
   month: 10
   style: "w-full text-center cursor-pointer font-nsk caption-13 font-bold mr-[15px]  "
   year: 2023
} 
## 스크린샷?
<img width="1081" alt="image" src="https://github.com/Guzzing/Studay_Client/assets/106604926/f3838733-6ef5-4188-af83-1e6ca9397da0">

## 참고 사항
- 현재일자일때 및 선택했을때 어떻게 보여줄지 CSS스타일 적용이 아직 안되었습니다.
- 스케줄이 등록되었을때 CSS 스타일 적용이 안되었습니다.
- 머지 후 유진님이 만들어 주신 아이콘 적용을 해야합니다.(이전, 다음 달)

close #9 
