### PR TITLE
feat: 메인페이지 생성

### DIFF
--- a/src/assets/icon/Add.svg
+++ b/src/assets/icon/Add.svg
@@ -1,4 +1,4 @@
-<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="current" height="current" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
 <circle cx="15" cy="15" r="11.25" fill="#57A4FF"/>
 <path d="M15 18.75L15 11.25" stroke="white" stroke-width="1.2" stroke-linecap="round"/>
 <path d="M18.75 15L11.25 15" stroke="white" stroke-width="1.2" stroke-linecap="round"/>

--- a/src/components/common/informationBox/InformationBox.tsx
+++ b/src/components/common/informationBox/InformationBox.tsx
@@ -15,11 +15,11 @@ const InformationBox = ({
         'p-[14px] w-[345px] h-[120px] font-nsk overflow-hidden rounded-[10px] bg-white-0'
       }
     >
-      <div className={'w-full h-full flex'}>
+      <div className={'w-full h-full flex items-center'}>
         <Profile imageSize={'M'} canEdit={true} />
         <div
           className={
-            'relative w-[240px] h-full pl-[17px] flex flex-col justify-between'
+            'relative w-[240px] h-full pl-[17px] flex flex-col justify-center gap-[5px]'
           }
         >
           <p className={'subHead-18 font-nsk text-black-900'}>{mainTitle}</p>

--- a/src/components/common/informationBox/InformationBox.tsx
+++ b/src/components/common/informationBox/InformationBox.tsx
@@ -3,7 +3,7 @@ import Icon from '../icon/Icon'
 import Profile from '../profile/Profile'
 
 // CHECK
-// Profile component가 머지되면 바로 프로필 컴포넌트 반영할게요!
+
 const InformationBox = ({
   mainTitle,
   subTitle,
@@ -12,7 +12,7 @@ const InformationBox = ({
   return (
     <div
       className={
-        'p-[14px] w-[345px] h-[120px] font-nsk overflow-hidden rounded-[10px] bg-white-200'
+        'p-[14px] w-[345px] h-[120px] font-nsk overflow-hidden rounded-[10px] bg-white-0'
       }
     >
       <div className={'w-full h-full flex'}>

--- a/src/components/common/spacing/Spacing.tsx
+++ b/src/components/common/spacing/Spacing.tsx
@@ -1,6 +1,6 @@
 interface SpacingProps {
   size: number
-  color: string
+  color?: string
 }
 
 /**

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,3 +1,0 @@
-export default function HomePage() {
-  return <div>{'HomePage'}</div>
-}

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,0 +1,27 @@
+import Icon from '@/components/common/icon/Icon'
+import InformationBox from '@/components/common/informationBox/InformationBox'
+import Spacing from '@/components/common/spacing/Spacing'
+const HomePage = () => {
+  return (
+    <div className={'bg-white-100 w-full h-full'}>
+      <Spacing size={100} />
+      <div className={'flex flex-col items-center gap-[20px]'}>
+        <InformationBox
+          mainTitle={'김잼민'}
+          subTitle={'중학교 3학년'}
+          description={'잼민이는 지금 수학학원에 있어요!'}
+        />
+        <InformationBox
+          mainTitle={'빵빵이'}
+          subTitle={'중학교 3학년'}
+          description={'빵빵이는 지금 영어학원에 있어요!'}
+        />
+      </div>
+      <div className={'absolute right-[10px] bottom-[90px] cursor-pointer'}>
+        <Icon icon={'Add'} classStyle={'h-[60px] w-[60px]'} />
+      </div>
+    </div>
+  )
+}
+
+export default HomePage

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,20 +1,28 @@
 import { Outlet, createBrowserRouter } from 'react-router-dom'
+import Header from '@/components/common/header/Header'
+import NavigationBar from '@/components/common/navigationbar/NavigationBar'
 import ErrorPage from '@/pages/ErrorPage'
+import HomePage from '@/pages/home/HomePage'
 
 export const router = createBrowserRouter(
   [
     {
       path: '/',
       element: (
-        <div>
-          {'고정!'}
+        <div className={'w-full h-full relative'}>
           <Outlet />
         </div>
       ),
       children: [
         {
           index: true,
-          element: <p>{'mainpage 추가내용'}</p>,
+          element: (
+            <>
+              <Header headerType={'Logo'} pageTitle={'아이 정보 한눈에 보기'} />
+              <HomePage />
+              <NavigationBar selectIcon={'Home'} />
+            </>
+          ),
           errorElement: <ErrorPage />
         },
         {
@@ -103,5 +111,5 @@ export const router = createBrowserRouter(
       ]
     }
   ],
-  { basename: '/studay' }
+  { basename: '/' }
 )

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,10 +1,13 @@
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300&display=swap');
+@import url(http://fonts.googleapis.com/earlyaccess/notosanskr.css);
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 
 * {
   box-sizing: border-box;
+}
+.notosanskr * {
+  font-family: 'Noto Sans KR', sans-serif;
 }
 body {
   width: 100vw;
@@ -13,17 +16,23 @@ body {
   justify-content: center;
   align-items: center;
 }
-.App {
+#root {
   position: relative;
   width: 390px;
   height: 844px;
-  background-color: gray;
 }
 @layer components {
+  .headline-30 {
+    font-family: 'nsk';
+    font-size: 30px;
+    font-weight: 600;
+    line-height: 17px;
+    color: #000;
+  }
   .headline-30-black-lg {
     font-family: 'nsk';
     font-size: 30px;
-    font-weight: 700;
+    font-weight: 600;
     line-height: 17px;
     color: #000;
   }
@@ -39,7 +48,7 @@ body {
   .headline-30-500 {
     font-family: 'nsk';
     font-size: 30px;
-    font-weight: 500;
+    font-weight: 600;
     line-height: 40px;
     letter-spacing: -0.33px;
   }
@@ -52,12 +61,17 @@ body {
     color: #000;
   }
 
-  .headline-20-black {
+  .headline-20 {
     font-family: 'nsk';
     font-size: 20px;
     font-weight: 700;
     line-height: 24px;
-    color: #000;
+  }
+  .subHead-18 {
+    font-family: 'nsk';
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 24px;
   }
   .subHead-18-black {
     font-family: 'nsk';
@@ -66,11 +80,17 @@ body {
     line-height: 24px;
     color: #000;
   }
+  .subHead-16 {
+    font-family: 'nsk';
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 24px;
+  }
 
   .subHead-16-black {
     font-family: 'nsk';
     font-size: 16px;
-    font-weight: 600;
+    font-weight: 700;
     line-height: 24px;
     color: #000;
   }
@@ -90,17 +110,23 @@ body {
     line-height: 24px;
     color: #fc4c4e;
   }
+  .subHead-13 {
+    font-family: 'nsk';
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 24px;
+  }
   .subHead-13-black {
     font-family: 'nsk';
-    font-size: 17px;
-    font-weight: 500;
+    font-size: 13px;
+    font-weight: 600;
     line-height: 24px;
     color: #000;
   }
 
   .body-18-blue {
     font-family: 'nsk';
-    font-size: 14px;
+    font-size: 18px;
     font-weight: 500;
     line-height: 24px;
     letter-spacing: -0.15px;
@@ -110,15 +136,15 @@ body {
   .body-18-black-lg {
     font-family: 'nsk';
     font-size: 18px;
-    font-weight: 400;
+    font-weight: 500;
     line-height: 24px;
     letter-spacing: -0.2px;
     color: #000;
   }
   .body-18-black-sm {
     font-family: 'nsk';
-    font-size: 13px;
-    font-weight: 400;
+    font-size: 18px;
+    font-weight: 500;
     line-height: 24px;
     letter-spacing: -0.1px;
     color: #000;
@@ -126,25 +152,22 @@ body {
   .body-18-gray {
     font-family: 'nsk';
     font-size: 18px;
-    font-weight: 400;
+    font-weight: 500;
     line-height: 40px;
     letter-spacing: -2px;
     color: #808080;
   }
-  .body-16-black {
+  .body-16 {
     font-family: 'nsk';
     font-size: 16px;
-    font-weight: 500;
+    font-weight: 600;
     line-height: 24px;
-    color: #000;
   }
-  .body-15-black {
+  .body-15 {
     font-family: 'nsk';
     font-size: 15px;
     font-weight: 500;
-    line-height: 20px;
-    color: #000;
-    letter-spacing: -0.165px;
+    line-height: 24px;
   }
   .body-15-gray {
     font-family: 'nsk';
@@ -153,30 +176,25 @@ body {
     line-height: 20px;
     color: #808080;
   }
-
-  .body-14-black {
+  .body-14 {
     font-family: 'nsk';
     font-size: 14px;
     font-weight: 500;
     line-height: 24px;
-    color: #000;
   }
-
   .body-14-gray {
     font-family: 'nsk';
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 500;
     line-height: 24px;
     color: #808080;
   }
-  .caption-13-black {
+  .caption-13 {
     font-family: 'nsk';
     font-size: 13px;
     font-weight: 400;
     line-height: 17px;
-    color: #000;
   }
-
   .caption-13-gray {
     font-family: 'nsk';
     font-size: 13px;
@@ -194,7 +212,7 @@ body {
   .placeholder {
     font-family: 'nsk';
     font-size: 18px;
-    font-weight: 400;
+    font-weight: 500;
     line-height: 24px;
     letter-spacing: -0.2;
     color: #808080;
@@ -203,14 +221,12 @@ body {
   .button-white {
     font-family: 'nsk';
     font-size: 16px;
-    font-weight: 700;
+    font-weight: 600;
     line-height: 24px;
     color: #fff;
   }
-
   .body-10 {
     font-size: 10px;
-    font-style: normal;
     font-weight: 500;
   }
 }


### PR DESCRIPTION
## 내용 설명
메인페이지를 구현했습니다.

## 구현 내용
- font 클래스 default 값으로 수정 -> 이제 색깔 있는 것만 뒤에 접미사가 붙습니다.
 ex. `body-16-black` -> `body-16` 으로 수정
`body-16-blue` 와 같이 색깔 있는 것은 그대로..
- 메인페이지 제작

## 스크린샷?
<img width="384" alt="스크린샷 2023-10-31 오후 7 02 30" src="https://github.com/Guzzing/Studay_Client/assets/67894159/f15774dd-2a4f-4124-aef8-d3e0656d18d8">

## 장애물?
추후 NavigationBar에 있는 아이콘과 border 수정을 해야 할 수도 있을 것 같습니다. 
## PR 포인트
- `/studay` 가 기본 url로 되어 있던데, 어짜피 배포하면 도메인에 `studay` 들어갈거니까, 그거 빼고 `/`를 기본 url로 세팅해놨어용 
close #63 
