### PR TITLE
아이 프로필사진 기본이미지 변경(아구몬 => 기본 이미지)

### DIFF
--- a/src/components/common/informationBox/InformationBox.tsx
+++ b/src/components/common/informationBox/InformationBox.tsx
@@ -8,6 +8,7 @@ const InformationBox = ({
   mainTitle,
   subTitle,
   description,
+  imageUrl,
   onClick // CHECK : description은 글자 수 설정을 해놓으면 좋을 것 같습니다!
 }: InformationBoxProps) => {
   return (
@@ -16,7 +17,7 @@ const InformationBox = ({
         'p-[14px] w-[345px] h-[120px] font-nsk overflow-hidden rounded-[10px] bg-white-0'
       }>
       <div className={'w-full h-full flex items-center'}>
-        <Profile imageSize={'M'} canEdit={true} />
+        <Profile imageSize={'M'} canEdit={true} imageUrl={imageUrl} />
         <div
           className={
             'relative w-[240px] h-full pl-[17px] flex flex-col justify-center gap-[5px]'

--- a/src/components/common/informationBox/InformationBoxType.ts
+++ b/src/components/common/informationBox/InformationBoxType.ts
@@ -1,7 +1,7 @@
 import { ComponentProps } from 'react'
 
 export interface InformationBoxProps extends ComponentProps<'div'> {
-  image?: string
+  imageUrl?: string
   mainTitle: string
   subTitle: string
   description: string

--- a/src/libs/api/children/ChildrenType.ts
+++ b/src/libs/api/children/ChildrenType.ts
@@ -3,6 +3,7 @@ export interface GetChildrenInfoResponse {
   grade: string
   nickname: string
   schedule: string
+  profileImageUrl: string
 }
 
 export interface EditChildInfoRequest {

--- a/src/libs/api/mypage/myPageType.ts
+++ b/src/libs/api/mypage/myPageType.ts
@@ -2,7 +2,7 @@ interface Children {
   childId: number
   childName: string
   schedule: string
-  profileImageUrl: string
+  childProfileImageUrl: string
 }
 export interface GetMyPageResponse {
   nickname: string

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -12,6 +12,7 @@ const HomePage = () => {
     queryKey: ['children'],
     queryFn: () => getChildrenInfo()
   })
+  console.log(data)
   if (isLoading) {
     return <Loading />
   }
@@ -28,6 +29,7 @@ const HomePage = () => {
                 mainTitle={data.nickname}
                 subTitle={data.grade}
                 description={data.schedule}
+                imageUrl={data.profileImageUrl}
                 onClick={() =>
                   navigate(`edit/${data.childId}`, {
                     state: {

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -49,9 +49,10 @@ const MyPage = () => {
         </div>
         <div className={'flex overflow-x-scroll'}>
           {myPageData.childInformationResponses.map(
-            ({ childId, childName }) => (
+            ({ childId, childName, childProfileImageUrl }) => (
               <li key={childId} className={`list-none px-[10px] flex-shrink-0`}>
                 <Profile
+                  imageUrl={childProfileImageUrl}
                   imageSize={'M'}
                   imageLabel={childName}
                   canEdit={true}


### PR DESCRIPTION
## 내용 설명
홈페이지, 마이페이지 기본 이미지 수정하였습니다. 

## 구현 내용

## 스크린샷?
<h3>홈페이지<h3>
<img width="397" alt="image" src="https://github.com/Guzzing/Studay_Client/assets/85999976/c0018372-0e0b-4e9e-b0b8-d8e13ef8730d">

<h3>마이페이지</h3>
<img width="401" alt="image" src="https://github.com/Guzzing/Studay_Client/assets/85999976/4118e239-1cdc-4ccb-8307-327c00dc0859">

## 참고 사항
<li>1. 지금 이미지가 하나로만 나오는데, 백엔드에서 수정해주신다고 하셨습니다 </li>
<li>2. child edit페이지도 같이 수정하려고했는데, 로직도 있고, 랜더링 문제 해결해주실 때 같이 바꿔주시면 될 듯해서 손 대지 않았습니다!</li>

## 궁금한 점

close #181 
