### PR TITLE
Bug/188 sidebar scroll bug

### DIFF
--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -24,7 +24,7 @@ const HomePage = () => {
   return (
     <div
       className={
-        'relative bg-white-100 w-full h-[750px] overflow-x-hidden overflow-y-scroll'
+        'relative bg-white-100 w-full h-[750px] overflow-x-hidden overflow-y-scroll z-20'
       }>
       <SettingPage isOpen={toggleOpen} />
       <>
@@ -54,7 +54,7 @@ const HomePage = () => {
             </div>
           )}
         </div>
-        <div className={'absolute right-[10px] bottom-[90px] cursor-pointer'}>
+        <div className={'fixed right-[38%] bottom-[90px] cursor-pointer'}>
           <Icon
             icon={'Add'}
             classStyle={'h-[60px] w-[60px]'}

--- a/src/pages/map/MapPage.tsx
+++ b/src/pages/map/MapPage.tsx
@@ -107,7 +107,7 @@ const MapPage = () => {
   }
 
   return (
-    <div className={'relative bg-white-100 w-full h-full overflow-hidden'}>
+    <div className={'relative bg-white-100 w-full h-full overflow-hidden z-20'}>
       <SettingPage isOpen={toggleOpen} />
       <div>
         <Spacing size={80} />

--- a/src/pages/setting/SettingPage.tsx
+++ b/src/pages/setting/SettingPage.tsx
@@ -12,7 +12,6 @@ const SettingPage = ({ isOpen }: SettingPage) => {
   const navigate = useNavigate()
   return (
     <CSSTransition in={isOpen} timeout={300} classNames={'slide'} unmountOnExit>
-      {/* CHECK: unmountOnExit: 애니메이션 후 display: none역할 해서 dom에서 사라짐❗️ */}
       {() => (
         <div
           className={


### PR DESCRIPTION
## 내용 설명
<li>
1. scroll이 되면 setting page가 scoll 될 때 header보다 위에있는 문제 해결
</li>
<li>
2. Homepage에 있는 floating icon이 absolute로 처리가 되어있어 부모가 scroll이 되면 같이 따라올라가서 fixed로 고정
</li>

## 구현 내용

## 스크린샷?
<h2>헤더 아래로 내려옵니다</h2>
<img width="383" alt="image" src="https://github.com/Guzzing/Studay_Client/assets/85999976/5a86262e-d72c-4675-be93-e0584e70cbc1">


## 참고 사항

## 궁금한 점

close #188 
