### PR TITLE
fix: EditChildren page 아이 default image 변경(아구몬❌)

### DIFF
--- a/src/components/common/profile/Profile.tsx
+++ b/src/components/common/profile/Profile.tsx
@@ -33,7 +33,14 @@ const Profile = ({
             : PROFILE_SIZE['XL']
         } rounded-full`}
       />
-      {imageLabel && <p className={'relative text-center'}>{imageLabel}</p>}
+      {imageLabel && (
+        <p
+          className={
+            'relative text-center text-ellipsis overflow-hidden whitespace-nowrap w-[70px] text-center'
+          }>
+          {imageLabel}
+        </p>
+      )}
     </div>
   )
 }

--- a/src/pages/EditChildren/EditChildren.tsx
+++ b/src/pages/EditChildren/EditChildren.tsx
@@ -42,7 +42,11 @@ const EditChildren = () => {
   return (
     <div className={'flex flex-col items-center relative h-full'}>
       <Spacing size={150} />
-      <Profile imageSize={'XL'} canEdit={true} />
+      <Profile
+        imageSize={'XL'}
+        canEdit={true}
+        imageUrl={childInfo?.profileImageUrl}
+      />
       <div className={'mt-[30px]'}></div>
       <ListRow
         leftElement={<div className={'font-nsk subHead-18'}>{'이름'}</div>}

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -55,18 +55,23 @@ const MyPage = () => {
             />
           </div>
           <div className={'flex overflow-x-scroll'}>
-            {data?.childInformationResponses.map(({ childId, childName }) => (
-              <li key={childId} className={`list-none px-[10px] flex-shrink-0`}>
-                <Profile
-                  imageSize={'M'}
-                  imageLabel={childName}
-                  canEdit={true}
-                  onClick={() =>
-                    navigate(`/edit/${childId}`, { state: childId })
-                  }
-                />
-              </li>
-            ))}
+            {data?.childInformationResponses.map(
+              ({ childId, childName, childProfileImageUrl }) => (
+                <li
+                  key={childId}
+                  className={`list-none px-[10px] flex-shrink-0`}>
+                  <Profile
+                    imageSize={'M'}
+                    imageLabel={childName}
+                    imageUrl={childProfileImageUrl}
+                    canEdit={true}
+                    onClick={() =>
+                      navigate(`/edit/${childId}`, { state: childId })
+                    }
+                  />
+                </li>
+              )
+            )}
           </div>
         </div>
         <ListRow


### PR DESCRIPTION
## 내용 설명
- EditChildren 페이지 아구몬에서 아이 이미지로 기본이미지 변경하였습니다
- myPage에도 이미지 업데이트 하였고, 글자가 넘어갈 시 ...처리 해줬습니다
## 스크린샷?
### children edit page
<img width="387" alt="image" src="https://github.com/Guzzing/Studay_Client/assets/85999976/9ad64b49-cd9a-4111-9f9d-16e40a8aa16e">

### myPage 
<img width="376" alt="image" src="https://github.com/Guzzing/Studay_Client/assets/85999976/efbf9a97-beaf-41c9-a9c5-cd327af934f3">

## 참고 사항

## 궁금한 점

close #253 
