### PR TITLE
[Fix] : 대시보드 생성시 자식의 이름이 그대로 상태유지되는 현상 개선 

### DIFF
--- a/src/components/dashboard/SelectChild.tsx
+++ b/src/components/dashboard/SelectChild.tsx
@@ -26,6 +26,8 @@ const SelectChild = ({
       })
       const idx = indexAry.find((data) => data > 0)
       if (idx) childrenSelectRef.current.selectedIndex = idx
+    } else {
+      if (childrenSelectRef.current) childrenSelectRef.current.selectedIndex = 0
     }
   }, [academyInfo.childId, childrenSelectRef])
 

--- a/src/pages/academy/addSchedule/AddPayment.tsx
+++ b/src/pages/academy/addSchedule/AddPayment.tsx
@@ -14,7 +14,6 @@ const AddPayment = () => {
   const inputRef = useRef<HTMLInputElement>(null)
   const [academyInfo, setAcademyInfo] = useAtom(academyInfoAtom)
   const [paymentDate, setPaymentDate] = useState(new Date())
-  console.log(academyInfo)
   const [paymentInfo, setPaymentInfo] = useState({
     paymentName: '',
     paymentFee: 0

--- a/src/pages/academy/editAcademy/index.tsx
+++ b/src/pages/academy/editAcademy/index.tsx
@@ -69,10 +69,6 @@ const EditAcademy = () => {
   }, [data])
 
   useEffect(() => {
-    console.log(academyInfo)
-  }, [academyInfo])
-
-  useEffect(() => {
     fetchDashboardData(dashboardId)
   }, [dashboardId])
 

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -14,7 +14,6 @@ const LoginPage = () => {
   const navigate = useNavigate()
   useEffect(() => {
     const req = async () => {
-      console.log('req실행!')
       try {
         if (getCode()?.method === 'kakao') {
           const kakaoToken = await getKaKaoAccessToken(pushData())


### PR DESCRIPTION
## 내용 설명
대시보드를 생성할 때 자식의 이름이 그대로 상태가 유지되어 사용자가 실수로 `childId`를 0을 넘겨줄 수 있는 상황을 개선했습니다. 
