### PR TITLE
스케줄 페이지 버그 수정

### DIFF
--- a/src/libs/api/schedule/scheduleApi.ts
+++ b/src/libs/api/schedule/scheduleApi.ts
@@ -13,7 +13,10 @@ export const getMonthScheduleAll = async ({
   year,
   month
 }: CalendarPropsType): Promise<CalendarResponse> => {
-  const res = await request.get(`/calendar/mark?year=${year}&month=${month}`)
+  const monthData = month > 9 ? month : `0${month}`
+  const res = await request.get(
+    `/calendar/mark?year=${year}&month=${monthData}`
+  )
   return res.data
 }
 
@@ -23,8 +26,9 @@ export const getDaySchedule = async ({
   day
 }: CalendarDayPropsType): Promise<DayScheduleResponse> => {
   const dayData = day > 9 ? day : `0${day}`
+  const monthData = month > 9 ? month : `0${month}`
   const res = await request.get(
-    `/calendar/date?date=${year}-${month}-${dayData}`
+    `/calendar/date?date=${year}-${monthData}-${dayData}`
   )
   return res.data
 }

--- a/src/libs/utils/date.ts
+++ b/src/libs/utils/date.ts
@@ -117,7 +117,7 @@ export const convertTo12HourFormat = (time: string) => {
 
   // 24시간 형식의 시간을 12시간 형식으로 변환합니다.
   const ampm = hours >= 12 ? '오후' : '오전'
-  const convertHours = hours === 0 ? 12 : hours % 12
+  const convertHours = hours > 12 ? hours - 12 : hours
   const timeFormat = `${ampm} ${convertHours}시`
 
   // 변환된 시간을 "오후 2시 30분" 형식으로 반환합니다.

--- a/src/pages/schedule/Schedule.tsx
+++ b/src/pages/schedule/Schedule.tsx
@@ -77,7 +77,7 @@ const Schedule = () => {
           holidays={monthSchedule?.holidays || []}
         />
       </div>
-      <div className={'flex flex-col overflow-y-auto h-1/3'}>
+      <div className={'flex flex-col overflow-y-auto h-[120px]'}>
         {scheduleData &&
           scheduleData.dateResponses.map((data, index) => (
             <>

--- a/src/pages/schedule/Schedule.tsx
+++ b/src/pages/schedule/Schedule.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { CalenderType } from '../../types/date.ts'
+import Loading from '@/components/Loading/Loading.tsx'
 import Calender from '@/components/common/calender/Calender.tsx'
 import Icon from '@/components/common/icon/Icon.tsx'
 import Profile from '@/components/common/profile/Profile.tsx'
@@ -42,7 +43,7 @@ const Schedule = () => {
         month: calenderState.nowMonth
       })
   })
-  const { data: scheduleData } = useQuery({
+  const { data: scheduleData, isLoading } = useQuery({
     queryKey: ['scheduleData', calenderState.toDay],
     queryFn: () =>
       getDaySchedule({
@@ -78,6 +79,7 @@ const Schedule = () => {
         />
       </div>
       <div className={'flex flex-col overflow-y-auto h-[120px]'}>
+        {isLoading && <Loading />}
         {scheduleData &&
           scheduleData.dateResponses.map((data, index) => (
             <>
@@ -122,7 +124,7 @@ const Schedule = () => {
               ))}
             </>
           ))}
-        {!scheduleData && (
+        {!scheduleData && !isLoading && (
           <span className={'mt-[20px] body-16 text-gray-600 text-center'}>
             {'생성된 스케줄이 없습니다. 스케줄을 생성해주세요!'}
           </span>


### PR DESCRIPTION
## 내용 설명
스케줄 페이지 버그 수정 하였습니다.

## 구현 내용
- 두번째 스케줄이 네비게이션 바에 가리는 문제 해결
- 스케줄이 있는 상태에도 처음 페이지 진입시 생성된 스케줄이 없다는 문구가 출력되는 문제 해결
- 오후 12시인 경우 오후 0시로 출력되는 문제 해결
- 스케줄 api호출시 month가 api에 규격에 맞지 않는 문제 해결