### PR TITLE
SelectCity 페이지 넓이가 서로 다른 문제 해결

### DIFF
--- a/src/components/selectcity/CityStep.tsx
+++ b/src/components/selectcity/CityStep.tsx
@@ -41,11 +41,11 @@ const CityStep = ({
     return [PROVINCE_TEXT, CITY_TEXT, TOWN_TEXT]
   }, [])
 
-  useEffect(()=>{
-    if(selectRef.current){
+  useEffect(() => {
+    if (selectRef.current) {
       selectRef.current.selectedIndex = 0
     }
-  },[currentStep])
+  }, [currentStep])
 
   return (
     <>
@@ -85,7 +85,7 @@ const CityStep = ({
           text={StepQuestionTitle[currentStep - 1]}
           step={currentStep}
         />
-        <div className={'mt-[14px]'}>
+        <div className={'mt-[14px] w-[323px]'}>
           <Select
             selecttype={'Single'}
             fullWidth={true}


### PR DESCRIPTION
## 내용 설명
SelectCity 페이지 넓이가 서로 다른 문제 해결 했습니다.

## 스크린샷?
<img width="432" alt="image" src="https://github.com/Guzzing/Studay_Client/assets/106604926/18efbcc0-4629-46ff-a138-28f7bd0a5d9e">
<img width="438" alt="image" src="https://github.com/Guzzing/Studay_Client/assets/106604926/936a00df-e99f-41ac-8004-c1652b06d625">
