### PR TITLE
fix: 파비콘 + 제목 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./src/assets/icon/Logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
-    <script type="text/javascript" src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpClientId=gheq9zrnsh"></script>
+    <title>Studay</title>
+    <script
+      type="text/javascript"
+      src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpClientId=gheq9zrnsh"
+    ></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## 내용 설명
브라우저 탭 파비콘 제목 수정했습니다.

## 스크린샷?
<img width="115" alt="image" src="https://github.com/Guzzing/Studay_Client/assets/85999976/a3359849-49d1-4721-ab72-2ec3847adb92">

close #304 
